### PR TITLE
Fix tvOS Bluetooth warning crash

### DIFF
--- a/Quake3-tvOS/Info.plist
+++ b/Quake3-tvOS/Info.plist
@@ -30,5 +30,7 @@
 	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Quake III: Arena would like to remain connected to nearby bluetooth Game Controllers and Game Pads even when you’re not using the app.</string>
 </dict>
 </plist>


### PR DESCRIPTION
This pull request fixes a crash on tvOS because of a missing `NSBluetoothAlwaysUsageDescription` key in the tvOS info Info.plist. The key from the iOS Info.plist file has been copied.

> This app has crashed because it attempted to access privacy-sensitive data without a usage description.  The app's Info.plist must contain an NSBluetoothAlwaysUsageDescription key with a string value explaining to the user how the app uses this data.